### PR TITLE
initial migration from private repo

### DIFF
--- a/pubsub/aws/aws.go
+++ b/pubsub/aws/aws.go
@@ -1,0 +1,239 @@
+package aws
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/golang/protobuf/proto"
+)
+
+// some arbitrary prefix I came up with to help distinguish between aws broker
+// queues, topics and queues, topics created for other means
+const topicNamePrefix = "pubsub__"
+
+// AWS SQS queue names cannot exceed 80 characters. The naming convention for
+// queues is to have the prefix+topic+subscriptionID, so we have to share these
+// 80 characters between the 3 items.
+const subscriptionIDMaxLength = 40
+
+// AWS SNS topic names can be up to 256 characters, but because of our naming
+// convention we're limited to the total 80-character max of the SQS name length.
+const topicNameMaxLength = 40 - len(topicNamePrefix)
+
+// Utility functions for performing AWS commands (create SNS topic, SQS queue, etc)
+
+// ensureSession will handle creating a session with the passed-in config or a
+// default config if nil was passed in
+func ensureSession(cfg *aws.Config) (*session.Session, error) {
+	if cfg == nil {
+		return session.NewSession(aws.NewConfig().WithCredentials(credentials.NewEnvCredentials()))
+	}
+	return session.NewSession(cfg)
+}
+
+// buildAWSTopicName takes in a topic name and returns a formatted version fitting
+// this broker's naming convention. Errors will be returned if the topic name is
+// too long.
+//
+// The going convention is that this broker prepends "pubsub__" to any topic
+// name, so that administration of topics and queues created by this aws broker
+// is easier from within the console or through any other management tools
+func buildAWSTopicName(topic string) (*string, error) {
+	if topicLength := len(topic); topicLength == 0 {
+		return nil, errors.New("topic name is required")
+	} else if topicLength > topicNameMaxLength {
+		return nil, fmt.Errorf("topic name must be no more than %v characters", topicNameMaxLength)
+	}
+
+	return aws.String(fmt.Sprintf("%s%s", topicNamePrefix, topic)), nil
+}
+
+// buildAWSQueueName takes in a topic and subscription and returns a formatted
+// version based on this broker's naming convention. Errors will be returned if
+// the topic/subscription combo is too long
+//
+// The going convention is that the queue name concatenates the aws-formatted
+// topic name with the subscriptionID, separated by a dash.
+//
+// Example: for topic `foo` and subcription `bar`, the queue name would be "pubsub__foo-bar"
+//
+// This is useful to prevent queue name clashes between message queues while
+// allowing an easy identifying mechanism for subscribing to a persistent queue.
+func buildAWSQueueName(topic, subscriptionID string) (*string, error) {
+	scrubbedTopic, topicErr := buildAWSTopicName(topic)
+	if topicErr != nil {
+		return nil, topicErr
+	}
+	if subIDLen := len(subscriptionID); subIDLen == 0 {
+		return nil, errors.New("subscriptionID is required")
+	} else if subIDLen > subscriptionIDMaxLength {
+		return nil, fmt.Errorf("subscriptionID must be no more than %v characters", subscriptionIDMaxLength)
+	}
+	return aws.String(fmt.Sprintf("%s-%s", *scrubbedTopic, subscriptionID)), nil
+}
+
+// ensureTopic takes a topic name and returns the topicArn, creating the SNS
+// topic if necessary
+func ensureTopic(topic string, snsClient snsiface.SNSAPI) (*string, error) {
+	scrubbedTopic, nameErr := buildAWSTopicName(topic)
+	if nameErr != nil {
+		return nil, nameErr
+	}
+
+	topicResp, topicErr := snsClient.CreateTopic(&sns.CreateTopicInput{Name: scrubbedTopic})
+	if topicErr != nil {
+		return nil, topicErr
+	}
+
+	return topicResp.TopicArn, nil
+}
+
+// ensureSubscription takes a topic and subscriptionID and returns the queueURL, creating
+// the topic and queue if necessary.
+//
+// This is broken down into the following discrete tasks:
+// 1. ensure the topic
+// 2. create queue, if necessary
+// 3. ensure queue has proper permissions to the given topic, if necessary
+// 4. subscribe queue to topic, if necessary
+//
+// TODO: consider edge cases where outside tampering of the queue could happen:
+// * what if someone subscribes the same queue to a different SNS topic?
+// * other stuff?
+func ensureSubscription(topic, subscriptionID string, snsClient snsiface.SNSAPI, sqsClient sqsiface.SQSAPI) (*string, error) {
+	queueName, nameErr := buildAWSQueueName(topic, subscriptionID)
+	if nameErr != nil {
+		return nil, nameErr
+	}
+
+	queueURL, queueErr := ensureQueue(queueName, sqsClient)
+	if queueErr != nil {
+		return nil, queueErr
+	}
+
+	topicArn, topicErr := ensureTopic(topic, snsClient)
+	if topicErr != nil {
+		return nil, topicErr
+	}
+
+	policyErr := ensureQueuePolicy(queueURL, topicArn, sqsClient)
+	if policyErr != nil {
+		return nil, policyErr
+	}
+
+	if subErr := ensureQueueSubscription(queueURL, topicArn, snsClient, sqsClient); subErr != nil {
+		return nil, subErr
+	}
+
+	return queueURL, nil
+}
+
+// ensureQueue returns the queueURL for the given queueName, creating the queue
+// if it doesn't exist
+func ensureQueue(queueName *string, sqsClient sqsiface.SQSAPI) (*string, error) {
+	queueURLResp, queueURLErr := sqsClient.GetQueueUrl(&sqs.GetQueueUrlInput{QueueName: queueName})
+	if queueURLErr == nil {
+		return queueURLResp.QueueUrl, nil
+	}
+	if awsErr, ok := queueURLErr.(awserr.Error); ok && awsErr.Code() == sqs.ErrCodeQueueDoesNotExist {
+		createResp, createErr := sqsClient.CreateQueue(&sqs.CreateQueueInput{
+			QueueName: queueName,
+		})
+		if createErr != nil {
+			return nil, createErr
+		}
+		return createResp.QueueUrl, nil
+	}
+	return nil, queueURLErr
+}
+
+// ensureQueuePolicy overwrites any existing policy for the given queue with one
+// that allows write permissions from the given SNS topicArn
+// An alternative to overwriting all policies for the given queue would be to just
+// make sure that this specific policy exists, but that's not a use case I'm
+// interested in right now
+func ensureQueuePolicy(queueURL, topicArn *string, sqsClient sqsiface.SQSAPI) error {
+	// some weird policy thing I stole from Andrei's POC
+	sqsPolicy := `
+	{
+	    "Version": "2012-10-17",
+	    "Statement": [
+	        {
+	            "Effect": "Allow",
+	            "Principal": {
+	                "AWS": "*"
+	            },
+	            "Action": "SQS:SendMessage",
+	            "Resource": "*",
+	            "Condition": {
+	                "ArnEquals": {
+	                    "aws:SourceArn": "%s"
+	                }
+	            }
+	        }
+	    ]
+	}
+	`
+	_, policyErr := sqsClient.SetQueueAttributes(&sqs.SetQueueAttributesInput{
+		QueueUrl: queueURL,
+		Attributes: map[string]*string{
+			"Policy": aws.String(fmt.Sprintf(sqsPolicy, *topicArn)),
+		},
+	})
+	return policyErr
+}
+
+// ensureQueueSubscription subscribes the given SQS queue to the given SNS topic
+func ensureQueueSubscription(queueURL, topicArn *string, snsClient snsiface.SNSAPI, sqsClient sqsiface.SQSAPI) error {
+	arnResp, attrErr := sqsClient.GetQueueAttributes(&sqs.GetQueueAttributesInput{
+		QueueUrl:       queueURL,
+		AttributeNames: []*string{aws.String("QueueArn")},
+	})
+	if attrErr != nil {
+		return attrErr
+	}
+	queueARN := arnResp.Attributes["QueueArn"]
+
+	_, subErr := snsClient.Subscribe(&sns.SubscribeInput{
+		Protocol: aws.String("sqs"),
+		TopicArn: topicArn,
+		Endpoint: queueARN,
+	})
+	if subErr != nil {
+		return subErr
+	}
+	return nil
+}
+
+// encodeToSNSMessage converts the given proto message into a string to be used
+// by SNS
+func encodeToSNSMessage(msg proto.Message) (*string, error) {
+	bytes, err := proto.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	return aws.String(base64.StdEncoding.EncodeToString(bytes)), nil
+}
+
+// decodeFromSQSMessage takes the sqs.Message.Body and unmarshals it into a []byte
+func decodeFromSQSMessage(sqsMessage *string) ([]byte, error) {
+	v := new(struct {
+		Payload string `json:"Message"`
+	})
+	umErr := json.Unmarshal([]byte(*sqsMessage), v)
+	if umErr != nil {
+		return nil, umErr
+	}
+
+	return base64.StdEncoding.DecodeString(v.Payload)
+}

--- a/pubsub/aws/aws_test.go
+++ b/pubsub/aws/aws_test.go
@@ -1,0 +1,190 @@
+package aws
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/golang/protobuf/proto"
+)
+
+func TestTopicAndQueueNamingMaxLengths(t *testing.T) {
+	totalLength := len(topicNamePrefix) + topicNameMaxLength + subscriptionIDMaxLength
+	if totalLength > 80 {
+		t.Errorf("the total length for a prefix+topic+subscription cannot exceed 80 characters, but is %d", totalLength)
+	}
+}
+
+func TestBuildAWSQueueName(t *testing.T) {
+	{ // verify a bad topic name returns an error
+		_, err := buildAWSQueueName(strings.Repeat("a", topicNameMaxLength+1), "subscriptionID")
+		if err == nil {
+			t.Error("expected buildAWSQueueName to return an error for a bad topic, but didn't")
+		}
+	}
+	{ // verify an empty subscriptionID returns an error
+		_, err := buildAWSQueueName("topic", "")
+		if err == nil {
+			t.Error("expected buildAWSQueueName to return an error for an empty subscriptionID, but didn't")
+		}
+	}
+	{ // verify a too long subscriptionID returns an error
+		_, err := buildAWSQueueName("topic", strings.Repeat("a", subscriptionIDMaxLength+1))
+		if err == nil {
+			t.Error("expected buildAWSQueueName to return an error for a too long subscriptionID, but didn't")
+		}
+	}
+	{ // verify a successful queue name
+		expectedQueueName := "pubsub__topic-subscriptionID"
+		actualQueueName, err := buildAWSQueueName("topic", "subscriptionID")
+		if *actualQueueName != expectedQueueName {
+			t.Errorf("expected queuename to be \"%s\", but was \"%s\"", expectedQueueName, *actualQueueName)
+		}
+		if err != nil {
+			t.Errorf("expected buildAWSQueueName to not return an error, but returned: %v", err)
+		}
+	}
+}
+
+func TestEnsureQueue(t *testing.T) {
+	sqsSpy := mockSQS{}
+	queueName := aws.String("test queue name")
+	{ // verify nil error returns queue url
+		expectedQueueURL := aws.String("expected queue url")
+		sqsSpy.stubbedGetQueueURLOutput = &sqs.GetQueueUrlOutput{QueueUrl: expectedQueueURL}
+		actualQueueURL, err := ensureQueue(queueName, &sqsSpy)
+		if err != nil {
+			t.Errorf("expected GetQueueUrl not to return error, but got \"%v\"", err)
+		} else if *actualQueueURL != *expectedQueueURL {
+			t.Errorf("expected GetQueueUrl to return \"%s\", but got \"%s\"", *expectedQueueURL, *actualQueueURL)
+		}
+	}
+	{ // verify returning a 404 error creates the queue and returns the created queueURL
+		expectedCreatedQueueURL := aws.String("expected queue URL")
+		sqsSpy.stubbedGetQueueURLError = awserr.New(sqs.ErrCodeQueueDoesNotExist, "foo", errors.New("foo"))
+		sqsSpy.stubbedCreateQueueOutput = &sqs.CreateQueueOutput{QueueUrl: expectedCreatedQueueURL}
+		actualCreatedQueueURL, actualErr := ensureQueue(queueName, &sqsSpy)
+		if sqsSpy.spiedCreateQueueInput == nil {
+			t.Error("expected sqs.CreateQueue to be called, but wasn't")
+		} else {
+			actualQueueName := sqsSpy.spiedCreateQueueInput.QueueName
+			if actualQueueName != queueName {
+				t.Errorf("expected sqs.CreateQueue to be called for queue name \"%s\", but was called with \"%s\"", *queueName, *actualQueueName)
+			}
+			if expectedCreatedQueueURL != actualCreatedQueueURL {
+				t.Errorf("expected ensureQueue to return queueURL \"%s\", but was \"%s\"", *expectedCreatedQueueURL, *actualCreatedQueueURL)
+			}
+			if actualErr != nil {
+				t.Errorf("expected ensureQueue to not return an error, but returned: %v", actualErr)
+			}
+		}
+	}
+	{ // verify ensureQueue forwards any sqs.CreateQueue errors
+		expectedError := errors.New("expected sqs.CreateQueue error")
+		sqsSpy.stubbedCreateQueueError = expectedError
+		_, actualError := ensureQueue(queueName, &sqsSpy)
+		if expectedError != actualError {
+			t.Errorf("expected sqs.CreateQueue to return error \"%s\", but returned \"%s\"", expectedError.Error(), actualError.Error())
+		}
+	}
+	{ // verify ensureQueue returns any non-404 errors from sqs.GetQueueURL
+		expectedError := errors.New("expected sqs.GetQueueURL error")
+		sqsSpy.stubbedGetQueueURLError = expectedError
+		_, actualError := ensureQueue(queueName, &sqsSpy)
+		if expectedError != actualError {
+			t.Errorf("expected sqs.GetQueueURL to return error \"%s\", but return \"%s\"", expectedError.Error(), actualError.Error())
+		}
+	}
+}
+
+func TestEnsureQueuePolicy(t *testing.T) {
+	sqsSpy := mockSQS{}
+	queueURL := aws.String("queueURL")
+	topicArn := aws.String("topicArn")
+	{ // verify ensureQueuePolice forwards any sqs.SetQueueAttributes errors
+		expectedErr := errors.New("expected SetQueueAttributes error")
+		sqsSpy.stubbedSetQueueAttributesError = expectedErr
+		actualErr := ensureQueuePolicy(queueURL, topicArn, &sqsSpy)
+		if actualErr != expectedErr {
+			t.Errorf("expected sqs.SetQueueAttributes to return error :\n%v\nbut was:\n%v", expectedErr, actualErr)
+		}
+	}
+}
+
+func TestEnsureQueueSubscription(t *testing.T) {
+	snsSpy := mockSNS{}
+	sqsSpy := mockSQS{}
+	queueURL := aws.String("queueURL")
+	topicArn := aws.String("topicArn")
+	{ // verify error is returned when GetQueueAttributes returns error
+		expectedErr := errors.New("test error for sqs.GetQueueAttributes")
+		sqsSpy.stubbedGetQueueAttributesError = expectedErr
+		actualErr := ensureQueueSubscription(queueURL, topicArn, &snsSpy, &sqsSpy)
+		if actualErr == nil {
+			t.Errorf("expected GetQueueAttributes to return error \"%s\", but didn't", expectedErr.Error())
+		} else if actualErr.Error() != expectedErr.Error() {
+			t.Errorf("expected GetQueueAttributes to return error \"%s\", but returned \"%s\"", expectedErr.Error(), actualErr.Error())
+		}
+		sqsSpy.stubbedGetQueueAttributesError = nil
+	}
+	expectedEndpoint := aws.String("expectedQueueArn")
+	sqsSpy.stubbedGetQueueAttributesOutput = &sqs.GetQueueAttributesOutput{
+		Attributes: map[string]*string{"QueueArn": expectedEndpoint},
+	}
+	{ // verify error is returned when sns.Subscribe returns error
+		expectedErr := errors.New("test error for sns.Subscribe")
+		snsSpy.stubbedSubscribeError = expectedErr
+		actualErr := ensureQueueSubscription(queueURL, topicArn, &snsSpy, &sqsSpy)
+		if actualErr == nil {
+			t.Errorf("expected Subscribe to return error \"%s\", but didn't", expectedErr.Error())
+		} else if actualErr.Error() != expectedErr.Error() {
+			t.Errorf("expected Subscribe to return error \"%s\", but returned \"%s\"", expectedErr.Error(), actualErr.Error())
+		}
+		snsSpy.stubbedSubscribeError = nil
+	}
+	{ // verify sns.Subscribe subscribes the given topicArn to the queueArn returned from sqs.GetQueueAttributes
+		ensureQueueSubscription(queueURL, topicArn, &snsSpy, &sqsSpy)
+		actualEndpoint := snsSpy.spiedSubscribeInput.Endpoint
+		if actualEndpoint != expectedEndpoint {
+			t.Errorf("expected Subscribe to have endpoint \"%s\", but was \"%s\"", *expectedEndpoint, *actualEndpoint)
+		}
+		actualTopicArn := snsSpy.spiedSubscribeInput.TopicArn
+		if actualTopicArn != topicArn {
+			t.Errorf("expected Subscribe topicArn to be \"%s\", but was \"%s\"", *topicArn, *actualTopicArn)
+		}
+	}
+	happyPathErr := ensureQueueSubscription(queueURL, topicArn, &snsSpy, &sqsSpy)
+	if happyPathErr != nil {
+		t.Errorf("expected happy path to not return error, but returned \"%s\"", happyPathErr.Error())
+	}
+}
+
+func TestDecodeFromSQSMessage(t *testing.T) {
+	expectedValue := "foo"
+
+	sqsMsg, werr := wrapIntoSQSMessage(&TestProto{Value: expectedValue}, nil)
+	if werr != nil {
+		t.Errorf("did not expect wrapIntoSQSMessage to return err, but returned: %v", werr)
+	}
+
+	var actualValue string
+	{
+		decoded, derr := decodeFromSQSMessage(sqsMsg.Body)
+		if derr != nil {
+			t.Errorf("did not expect decodeFromSQSMessage to return err, but returned: %v", derr)
+		}
+		decodedProto := TestProto{}
+		unmerr := proto.Unmarshal(decoded, &decodedProto)
+		if unmerr != nil {
+			t.Errorf("did not expect proto.Unmarshal to return err, but returned: %v", unmerr)
+		}
+		actualValue = decodedProto.Value
+	}
+
+	if expectedValue != actualValue {
+		t.Errorf("expected value to be \"%s\", but was \"%s\"", expectedValue, actualValue)
+	}
+}

--- a/pubsub/aws/instrumentation_test.go
+++ b/pubsub/aws/instrumentation_test.go
@@ -1,0 +1,189 @@
+package aws
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/uuid"
+)
+
+type mockSNS struct {
+	snsiface.SNSAPI
+	// whenever sns.CreateTopic is called, the input is stored here
+	spiedCreateTopicInput *sns.CreateTopicInput
+	// whenever sns.CreateTopic is called, this will be returned for the error field
+	stubbedCreateTopicError error
+	// whenever sns.PublishWithContext is called, the input is stored here
+	spiedPublishInput *sns.PublishInput
+
+	spiedSubscribeInput   *sns.SubscribeInput
+	stubbedSubscribeError error
+}
+
+// CreateTopic records the arguments passed in and returns the specified mocked error
+func (mock *mockSNS) CreateTopic(input *sns.CreateTopicInput) (*sns.CreateTopicOutput, error) {
+	mock.spiedCreateTopicInput = input
+	return &sns.CreateTopicOutput{TopicArn: aws.String("some fake topic arn")}, mock.stubbedCreateTopicError
+}
+
+func (mock *mockSNS) Subscribe(input *sns.SubscribeInput) (*sns.SubscribeOutput, error) {
+	mock.spiedSubscribeInput = input
+	return &sns.SubscribeOutput{}, mock.stubbedSubscribeError
+}
+
+// PublishWithContext records the input argument passed in and returns a stub response
+func (mock *mockSNS) PublishWithContext(ctx aws.Context, input *sns.PublishInput, opts ...request.Option) (*sns.PublishOutput, error) {
+	mock.spiedPublishInput = input
+	return &sns.PublishOutput{MessageId: aws.String("someUniqueMessageId")}, nil
+}
+
+type mockSQS struct {
+	sqsiface.SQSAPI
+
+	spiedGetQueueURLInput    *sqs.GetQueueUrlInput
+	stubbedGetQueueURLOutput *sqs.GetQueueUrlOutput
+	stubbedGetQueueURLError  error
+
+	spiedCreateQueueInput    *sqs.CreateQueueInput
+	stubbedCreateQueueOutput *sqs.CreateQueueOutput
+	stubbedCreateQueueError  error
+
+	spiedGetQueueAttributesInput    *sqs.GetQueueAttributesInput
+	stubbedGetQueueAttributesOutput *sqs.GetQueueAttributesOutput
+	stubbedGetQueueAttributesError  error
+
+	stubbedSetQueueAttributesError error
+
+	// if true, calling ReceiveMessage will return an error if there are no more
+	// messages in stubbedReceiveMessageMessages
+	useStrictMessageOrdering      bool
+	stubbedReceiveMessageMessages []*sqs.Message
+
+	spiedDeleteMessageInput   *sqs.DeleteMessageInput
+	stubbedDeleteMessageError error
+}
+
+func (mock *mockSQS) GetQueueUrl(input *sqs.GetQueueUrlInput) (*sqs.GetQueueUrlOutput, error) {
+	mock.spiedGetQueueURLInput = input
+	output := mock.stubbedGetQueueURLOutput
+	if output == nil && mock.stubbedGetQueueURLError == nil {
+		output = &sqs.GetQueueUrlOutput{}
+	}
+
+	return output, mock.stubbedGetQueueURLError
+}
+
+func (mock *mockSQS) CreateQueue(input *sqs.CreateQueueInput) (*sqs.CreateQueueOutput, error) {
+	mock.spiedCreateQueueInput = input
+	output := mock.stubbedCreateQueueOutput
+	if output == nil {
+		output = &sqs.CreateQueueOutput{}
+	}
+
+	return output, mock.stubbedCreateQueueError
+}
+
+func (mock *mockSQS) GetQueueAttributes(input *sqs.GetQueueAttributesInput) (*sqs.GetQueueAttributesOutput, error) {
+	mock.spiedGetQueueAttributesInput = input
+	output := mock.stubbedGetQueueAttributesOutput
+	if output == nil && mock.stubbedGetQueueAttributesError == nil {
+		output = &sqs.GetQueueAttributesOutput{}
+	}
+	return output, mock.stubbedGetQueueAttributesError
+}
+
+func (mock *mockSQS) SetQueueAttributes(*sqs.SetQueueAttributesInput) (*sqs.SetQueueAttributesOutput, error) {
+	return &sqs.SetQueueAttributesOutput{}, mock.stubbedSetQueueAttributesError
+}
+
+func (mock *mockSQS) ReceiveMessageWithContext(ctx aws.Context, input *sqs.ReceiveMessageInput, options ...request.Option) (*sqs.ReceiveMessageOutput, error) {
+	var msgs []*sqs.Message
+	numMsgs := int(*input.MaxNumberOfMessages)
+	if mock.stubbedReceiveMessageMessages == nil || len(mock.stubbedReceiveMessageMessages) == 0 {
+		if mock.useStrictMessageOrdering {
+			return nil, errors.New("no more messages to send")
+		}
+		msgs = []*sqs.Message{mustWrapIntoSQSMessage(&TestProto{Value: "foo"}, nil)}
+	} else if len(mock.stubbedReceiveMessageMessages) < numMsgs {
+		msgs = mock.stubbedReceiveMessageMessages
+		mock.stubbedReceiveMessageMessages = nil
+	} else {
+		msgs = mock.stubbedReceiveMessageMessages[:numMsgs]
+		mock.stubbedReceiveMessageMessages = mock.stubbedReceiveMessageMessages[numMsgs:]
+	}
+	return &sqs.ReceiveMessageOutput{Messages: msgs}, nil
+}
+
+func (mock *mockSQS) DeleteMessage(input *sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
+	mock.spiedDeleteMessageInput = input
+	return nil, mock.stubbedDeleteMessageError
+}
+
+// TestProto is a proto.Message implementation for testing
+type TestProto struct {
+	Value string `protobuf:"bytes,1,opt,name=value" json:"value,omitempty"`
+}
+
+func (m *TestProto) Reset()         { *m = TestProto{} }
+func (m *TestProto) String() string { return proto.CompactTextString(m) }
+func (*TestProto) ProtoMessage()    {}
+
+// mustWrapIntoSQSMessage panics if wrapIntoSQSMessage returns an error. This is
+// a convenience format for cases where you want to inline the wrapped message
+func mustWrapIntoSQSMessage(testMsg proto.Message, receiptHandle *string) *sqs.Message {
+	msg, err := wrapIntoSQSMessage(testMsg, receiptHandle)
+	if err != nil {
+		panic(err)
+	}
+
+	return msg
+}
+
+// wrapIntoSQSMessage helps wrap a given proto.Message into the format used when
+// receiving a message from an SQS queue
+func wrapIntoSQSMessage(testMsg proto.Message, receiptHandle *string) (*sqs.Message, error) {
+	encoded, err := encodeToSNSMessage(testMsg)
+	if err != nil {
+		return nil, fmt.Errorf("did not expect encodeToSNSMessage to return err, but returned: %v", err)
+	}
+	payload := struct {
+		Payload string `json:"Message"`
+	}{
+		*encoded,
+	}
+	marshalled, merr := json.Marshal(payload)
+	if merr != nil {
+		return nil, fmt.Errorf("did not expect json.Marshal to return err, but returned: %v", merr)
+	}
+
+	handle := receiptHandle
+	if handle == nil {
+		handle = aws.String(uuid.New().String())
+	}
+
+	return &sqs.Message{
+		Body:          aws.String(string(marshalled)),
+		ReceiptHandle: handle,
+	}, nil
+}
+
+func TestWrapIntoSQSMessage(t *testing.T) {
+	expected := TestProto{Value: "foo"}
+	msg := mustWrapIntoSQSMessage(&expected, nil)
+	bytes, _ := decodeFromSQSMessage(msg.Body)
+	actual := TestProto{}
+	proto.Unmarshal(bytes, &actual)
+
+	if expected.Value != actual.Value {
+		t.Errorf("expected \"%s\", got \"%s\"", expected.Value, actual.Value)
+	}
+}

--- a/pubsub/aws/publisher.go
+++ b/pubsub/aws/publisher.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+	"github.com/golang/protobuf/proto"
+	"github.com/infobloxopen/atlas-pubsub/pubsub"
+)
+
+// NewPublisher creates a new AWS message broker that will publish
+// messages to the given topic.
+// TODO: info on permissions needed within the config to make this work
+//
+// Topic names must be made up of only uppercase and lowercase
+// ASCII letters, numbers, underscores, and hyphens, and must be between 1 and
+// 247 characters long.
+func NewPublisher(config *aws.Config, topic string) (pubsub.Publisher, error) {
+	sess, err := ensureSession(config)
+	if err != nil {
+		return nil, err
+	}
+	return newPublisher(sns.New(sess), topic)
+}
+
+func newPublisher(snsClient snsiface.SNSAPI, topic string) (pubsub.Publisher, error) {
+	topicArn, err := ensureTopic(topic, snsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	p := publisher{
+		sns:      snsClient,
+		topicArn: *topicArn,
+	}
+
+	return p, nil
+}
+
+type publisher struct {
+	sns      snsiface.SNSAPI
+	topicArn string
+}
+
+func (p publisher) Publish(ctx context.Context, msg proto.Message) error {
+	message, err := encodeToSNSMessage(msg)
+	if err != nil {
+		return err
+	}
+	_, publishErr := p.sns.PublishWithContext(ctx, &sns.PublishInput{
+		TopicArn: aws.String(p.topicArn),
+		Message:  message,
+	})
+
+	return publishErr
+}

--- a/pubsub/aws/publisher_test.go
+++ b/pubsub/aws/publisher_test.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestNewPublisher verifies that aws creates a topic for the given topic name,
+// while handling invalid characters and string lengths appropriately, and
+// forwarding any errors encountered
+func TestNewPublisher(t *testing.T) {
+	{ // basic input validation tests
+		topicInputs := []string{
+			"",
+			strings.Repeat("a", topicNameMaxLength+1),
+		}
+		for _, input := range topicInputs {
+			if _, err := newPublisher(&mockSNS{}, input); err == nil {
+				t.Errorf("expected passing an invalid topic name to return an error, but didn't. \n topic input: \"%s\"", input)
+			}
+		}
+	}
+
+	{ // verify inputted topic names map properly to aws-appropriate names
+		spy := mockSNS{}
+		newPublisher(&spy, "foo")
+		if spy.spiedCreateTopicInput == nil {
+			t.Error("sns.CreateTopic was not called")
+		} else {
+			actual := *spy.spiedCreateTopicInput.Name
+			expected := "pubsub__foo"
+			if actual != expected {
+				t.Errorf("SNS topic name was incorrect, expected:\"%s\"actual:\"%s\"", expected, actual)
+			}
+		}
+	}
+
+	{ // verify aws errors are passed through
+		expectedErrorMessage := "some AWS error"
+		mock := mockSNS{stubbedCreateTopicError: errors.New(expectedErrorMessage)}
+		_, err := newPublisher(&mock, "foo")
+		if err == nil {
+			t.Error("Expected newPublisher to return an error, but didn't")
+		} else {
+			actual := err.Error()
+			if actual != expectedErrorMessage {
+				t.Errorf("Error message was incorrect, expected: \"%s\", actual: \"%s\"", expectedErrorMessage, actual)
+			}
+		}
+	}
+}
+
+func TestPublish(t *testing.T) {
+	expectedProto := TestProto{Value: "test value"}
+	spy := mockSNS{}
+
+	p := publisher{sns: &spy, topicArn: "foo"}
+	p.Publish(context.Background(), &expectedProto)
+	spiedInput := spy.spiedPublishInput
+
+	// verify the topic arn is what the publisher is set to
+	if *spiedInput.TopicArn != p.topicArn {
+		t.Errorf("AWS topic arn was incorrect, expected: \"%s\", actual: \"%s\"", p.topicArn, *spiedInput.TopicArn)
+	}
+	{ // verify the message looks the way it's supposed to
+		expectedRawMessage, _ := encodeToSNSMessage(&expectedProto)
+		expected := *expectedRawMessage
+		actual := *spiedInput.Message
+		if expected != actual {
+			t.Errorf("Base64-encoded message was not in expected format: \nexpected: \"%s\"\nactual:  \"%s\"", expected, actual)
+		}
+	}
+}

--- a/pubsub/aws/subscriber.go
+++ b/pubsub/aws/subscriber.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sns/snsiface"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/infobloxopen/atlas-pubsub/pubsub"
+)
+
+// NewAtMostOnceSubscriber creates an AWS message broker that will subcribe to
+// the given topic with at-most-once message delivery semantics
+// TODO: info on permissions needed within the config to make this work
+func NewAtMostOnceSubscriber(config *aws.Config, topic string) (pubsub.AtMostOnceSubscriber, error) {
+	panic("not implemented")
+}
+
+// NewAtLeastOnceSubscriber creates an AWS message broker that will subscribe to
+// the given topic with at-least-once message delivery semantics for the given
+// subscriptionID
+// TODO: info on permissions needed within the config to make this work
+func NewAtLeastOnceSubscriber(config *aws.Config, topic, subscriptionID string) (pubsub.AtLeastOnceSubscriber, error) {
+	sess, err := ensureSession(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return newAtLeastOnceSubscriber(sns.New(sess), sqs.New(sess), topic, subscriptionID)
+}
+
+func newAtLeastOnceSubscriber(snsClient snsiface.SNSAPI, sqsClient sqsiface.SQSAPI, topic, subscriptionID string) (pubsub.AtLeastOnceSubscriber, error) {
+	queueURL, err := ensureSubscription(topic, subscriptionID, snsClient, sqsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &atLeastOnceSubscriber{
+		sns:      snsClient,
+		sqs:      sqsClient,
+		queueURL: queueURL,
+	}, nil
+}
+
+type atLeastOnceSubscriber struct {
+	sns snsiface.SNSAPI
+	sqs sqsiface.SQSAPI
+
+	queueURL *string
+	wg       sync.WaitGroup
+}
+
+func (s *atLeastOnceSubscriber) Start(ctx context.Context) (<-chan pubsub.AtLeastOnceMessage, <-chan error) {
+	channel := make(chan pubsub.AtLeastOnceMessage)
+	errChannel := make(chan error)
+	go func() {
+		defer close(channel)
+
+		for {
+			select {
+			case <-ctx.Done():
+				s.wg.Wait()
+				return
+			default:
+				s.pull(ctx, channel, errChannel)
+			}
+		}
+	}()
+
+	return channel, errChannel
+}
+
+func (s *atLeastOnceSubscriber) pull(ctx context.Context, channel chan pubsub.AtLeastOnceMessage, errChannel chan error) {
+	s.wg.Add(1)
+	defer s.wg.Done()
+	resp, err := s.sqs.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            s.queueURL,
+		WaitTimeSeconds:     aws.Int64(20),
+		MaxNumberOfMessages: aws.Int64(1),
+	})
+	if err != nil {
+		errChannel <- err
+	} else {
+		for _, msg := range resp.Messages {
+			message, err := decodeFromSQSMessage(msg.Body)
+			if err != nil {
+				errChannel <- err
+			} else {
+				channel <- &atLeastOnceMessage{
+					ctx:        ctx,
+					subscriber: s,
+					messageID:  *msg.ReceiptHandle,
+					message:    message,
+				}
+			}
+		}
+	}
+}
+
+func (s *atLeastOnceSubscriber) AckMessage(ctx context.Context, messageID string) error {
+	_, error := s.sqs.DeleteMessage(&sqs.DeleteMessageInput{
+		QueueUrl:      s.queueURL,
+		ReceiptHandle: aws.String(messageID),
+	})
+	return error
+}
+
+func (s *atLeastOnceSubscriber) ExtendAckDeadline(ctx context.Context, messageID string, newDuration time.Duration) error {
+	panic("not implemented")
+}
+
+type atLeastOnceMessage struct {
+	ctx        context.Context
+	messageID  string
+	message    []byte
+	subscriber *atLeastOnceSubscriber
+}
+
+func (m *atLeastOnceMessage) MessageID() string {
+	return m.messageID
+}
+func (m *atLeastOnceMessage) Message() []byte {
+	return m.message
+}
+func (m *atLeastOnceMessage) ExtendAckDeadline(time.Duration) error {
+	panic("not implemented")
+}
+func (m *atLeastOnceMessage) Ack() error {
+	return m.subscriber.AckMessage(m.ctx, m.MessageID())
+}

--- a/pubsub/aws/subscriber_test.go
+++ b/pubsub/aws/subscriber_test.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/golang/protobuf/proto"
+)
+
+func TestStart(t *testing.T) {
+	expectedMessages := []string{"foo", "bar", "baz"}
+	sqsMock := mockSQS{useStrictMessageOrdering: true}
+	snsMock := mockSNS{}
+	{ // map the expected messages into sqs messages to be replayed
+		msgs := make([]*sqs.Message, len(expectedMessages))
+		for i, v := range expectedMessages {
+			msgs[i] = mustWrapIntoSQSMessage(&TestProto{Value: v}, nil)
+		}
+		msgs = append(msgs, &sqs.Message{Body: aws.String("some mangled message")})
+		sqsMock.stubbedReceiveMessageMessages = msgs
+	}
+
+	s, serr := newAtLeastOnceSubscriber(&snsMock, &sqsMock, "topic", "subscriptionID")
+	if serr != nil {
+		t.Errorf("expected no error from newSubscriber, but got: %v", serr)
+		return
+	}
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	msgChannel, errChannel := s.Start(ctx)
+
+	for _, expected := range expectedMessages {
+		msg := <-msgChannel
+		var actual string
+		{
+			pb := TestProto{}
+			unmarshalErr := proto.Unmarshal(msg.Message(), &pb)
+			if unmarshalErr != nil {
+				t.Errorf("expected no error from proto.Unmarshal, but got: %v", unmarshalErr)
+			}
+			actual = pb.Value
+		}
+		if expected != actual {
+			t.Errorf("expected message to be \"%s\", but was \"%s\"", expected, actual)
+		}
+
+		sqsMock.stubbedDeleteMessageError = errors.New("expected sqs.DeleteMessage error")
+		ackError := msg.Ack()
+		if ackError == nil {
+			t.Error("expected Ack to return an error, but didn't")
+		}
+		{
+			expectedReceiptHandle := msg.MessageID()
+			actualReceiptHandle := *sqsMock.spiedDeleteMessageInput.ReceiptHandle
+			if expectedReceiptHandle != actualReceiptHandle {
+				t.Errorf("expected sqs.DeleteMessage receiptHandle to be \"%s\", but was \"%s\"", expectedReceiptHandle, actualReceiptHandle)
+			}
+		}
+	}
+
+	err := <-errChannel
+	if err == nil {
+		t.Error("expected an error, but got nothing")
+	}
+
+	stop()
+	// hacky way to wait for the control loop to receive the cancellation and
+	// close the channel
+	time.Sleep(10 * time.Millisecond)
+
+	_, isOpen := <-msgChannel
+	if isOpen {
+		t.Error("expected channel to be closed, but was open")
+	}
+}

--- a/pubsub/interface.go
+++ b/pubsub/interface.go
@@ -1,0 +1,52 @@
+package pubsub
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// Publisher defines the basic interface for publishing messages to a message
+// broker
+type Publisher interface {
+	// Publishes the given message to the message broker. The topic should be
+	// known to the publisher prior to making this call
+	Publish(context.Context, proto.Message) error
+}
+
+// AtMostOnceSubscriber defines the interface for a subscriber with at-most-once
+// message delivery semantics
+type AtMostOnceSubscriber interface {
+	// Start creates a channel to the message broker for receiving messages
+	Start(context.Context) (<-chan []byte, <-chan error)
+}
+
+// AtLeastOnceSubscriber defines the interface for a subscriber with at-least-
+// once message delivery semantics
+type AtLeastOnceSubscriber interface {
+	// Start creates a channel to the message broker for receiving messages
+	Start(ctx context.Context) (<-chan AtLeastOnceMessage, <-chan error)
+	// AckMessage will delete the given message from its respective message queue
+	AckMessage(ctx context.Context, messageID string) error
+	// ExtendAckDeadline will postpone resending the given in-flight message for
+	// the specified duration
+	ExtendAckDeadline(ctx context.Context, messageID string, newDuration time.Duration) error
+}
+
+// AtLeastOnceMessage contains the payload for a message with at-least-once
+// delivery semantics
+type AtLeastOnceMessage interface {
+	// MessageID returns the ID that uniquely identifies this message. You can use
+	// this to Ack or extend the ack deadline from the Subscriber
+	MessageID() string
+	// Message returns the payload from the message
+	Message() []byte
+	// ExtendAckDeadline extends the duration that a message can remain in-flight
+	// before it will get added back to the message queue for redelivery. Call
+	// this if processing the message will take longer than the existing time window.
+	ExtendAckDeadline(time.Duration) error
+	// Ack will signal to the message broker that this given message has been
+	// processed and can be deleted
+	Ack() error
+}


### PR DESCRIPTION
There are only a few commits against the original repo, so I didn't think it was worth trying to preserve the history.

This is an exact port from the original repo, with the only changes being the import statements. I've excluded the example code that lived in other packages in the old repo, since it had lots of other stuff unrelated to pub/sub.