### PR TITLE
allow clearing a filter policy

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -194,17 +194,19 @@ func encodeFilterPolicy(filter map[string]string) (*string, error) {
 // value into a map to meet the subscriber interface
 func decodeFilterPolicy(filterPolicy *string) (map[string]string, error) {
 	decoded := make(map[string]string)
-	if filterPolicy != nil {
-		var unmarshalled map[string][]string
-		if err := json.Unmarshal([]byte(*filterPolicy), &unmarshalled); err != nil {
-			return nil, err
+	if filterPolicy == nil {
+		return decoded, nil
+	}
+
+	var unmarshalled map[string][]string
+	if err := json.Unmarshal([]byte(*filterPolicy), &unmarshalled); err != nil {
+		return nil, err
+	}
+	for k, v := range unmarshalled {
+		if len(v) > 1 {
+			return nil, fmt.Errorf("invalid filter policy for pub/sub: expected single filter parameter but got %v", v)
 		}
-		for k, v := range unmarshalled {
-			if len(v) > 1 {
-				return nil, fmt.Errorf("invalid filter policy for pub/sub: expected single filter parameter but got %v", v)
-			}
-			decoded[k] = v[0]
-		}
+		decoded[k] = v[0]
 	}
 	return decoded, nil
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -190,6 +190,25 @@ func encodeFilterPolicy(filter map[string]string) (*string, error) {
 	return aws.String(string(bytes)), err
 }
 
+// decodeFilterPolicy converts the given string from a sns.GetSubscriptionAttributesOutput.Attributes
+// value into a map to meet the subscriber interface
+func decodeFilterPolicy(filterPolicy *string) (map[string]string, error) {
+	decoded := make(map[string]string)
+	if filterPolicy != nil {
+		var unmarshalled map[string][]string
+		if err := json.Unmarshal([]byte(*filterPolicy), &unmarshalled); err != nil {
+			return nil, err
+		}
+		for k, v := range unmarshalled {
+			if len(v) > 1 {
+				return nil, fmt.Errorf("invalid filter policy for pub/sub: expected single filter parameter but got %v", v)
+			}
+			decoded[k] = v[0]
+		}
+	}
+	return decoded, nil
+}
+
 // encodeToSNSMessage converts the given message into a string to be used
 // by SNS
 func encodeToSNSMessage(msg []byte) *string {

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -128,6 +128,33 @@ func TestEncodeFilterPolicy(t *testing.T) {
 	}
 }
 
+func TestDecodeFilterPolicy(t *testing.T) {
+	testCases := []struct {
+		input    *string
+		expected interface{}
+	}{
+		{nil, make(map[string]string)},
+		{aws.String("{\"foo\":[\"bar\"]}"), map[string]string{"foo": "bar"}},
+		{aws.String("{\"foo\":[\"bar\", \"baz\"]}"), errors.New("")},
+		{aws.String("some mangled thing"), errors.New("")},
+	}
+	for _, testCase := range testCases {
+		expected := testCase.expected
+		if actual, err := decodeFilterPolicy(testCase.input); err != nil {
+			if _, ok := expected.(error); !ok {
+				t.Errorf("expected %v, but got %v", expected, err)
+			}
+			if len(actual) != 0 {
+				t.Errorf("expected filter policy to be empty, but was %v", actual)
+			}
+		} else {
+			if !reflect.DeepEqual(expected, actual) {
+				t.Errorf("expected %v, but got %v", expected, actual)
+			}
+		}
+	}
+}
+
 func TestDecodeFromSQSMessage(t *testing.T) {
 	expectedValue := []byte("foo")
 

--- a/aws/instrumentation_test.go
+++ b/aws/instrumentation_test.go
@@ -168,10 +168,10 @@ func (mock *mockSQS) DeleteMessage(input *sqs.DeleteMessageInput) (*sqs.DeleteMe
 
 // mustWrapIntoSQSMessage panics if wrapIntoSQSMessage returns an error. This is
 // a convenience format for cases where you want to inline the wrapped message
-func mustWrapIntoSQSMessage(testMsg []byte, receiptHandle *string, md map[string]string) *sqs.Message {
+func mustWrapIntoSQSMessage(t *testing.T, testMsg []byte, receiptHandle *string, md map[string]string) *sqs.Message {
 	msg, err := wrapIntoSQSMessage(testMsg, receiptHandle, md)
 	if err != nil {
-		panic(err)
+		t.Fatalf("error wrapping into SQS message: %v", err)
 	}
 
 	return msg
@@ -210,10 +210,10 @@ func wrapIntoSQSMessage(testMsg []byte, receiptHandle *string, md map[string]str
 
 // mustEncodeFilterPolicy panics if encodeFilterPolicy returns an error. This is
 // a convenience format for cases where you want to inline the call
-func mustEncodeFilterPolicy(filter map[string]string) *string {
+func mustEncodeFilterPolicy(t *testing.T, filter map[string]string) *string {
 	f, e := encodeFilterPolicy(filter)
 	if e != nil {
-		panic(e)
+		t.Fatalf("error encoding filter policy: %v", e)
 	}
 	return f
 }
@@ -222,7 +222,7 @@ func TestWrapIntoSQSMessage(t *testing.T) {
 	expected := []byte("foo")
 	expectedHandle := "bar"
 	expectedMd := map[string]string{"baz": "qux"}
-	msg := mustWrapIntoSQSMessage(expected, aws.String(expectedHandle), expectedMd)
+	msg := mustWrapIntoSQSMessage(t, expected, aws.String(expectedHandle), expectedMd)
 
 	{ // verify message body
 		actual, _ := decodeFromSQSMessage(msg.Body)

--- a/aws/instrumentation_test.go
+++ b/aws/instrumentation_test.go
@@ -208,6 +208,8 @@ func wrapIntoSQSMessage(testMsg []byte, receiptHandle *string, md map[string]str
 	}, nil
 }
 
+// mustEncodeFilterPolicy panics if encodeFilterPolicy returns an error. This is
+// a convenience format for cases where you want to inline the call
 func mustEncodeFilterPolicy(filter map[string]string) *string {
 	f, e := encodeFilterPolicy(filter)
 	if e != nil {

--- a/aws/subscriber.go
+++ b/aws/subscriber.go
@@ -168,18 +168,19 @@ func (s *awsSubscriber) ensureFilterPolicy(filter map[string]string) error {
 				return err
 			}
 			s.subscriptionArn = resp.SubscriptionArn
-		} else {
-			newFilterPolicy, err := encodeFilterPolicy(filter)
-			if err != nil {
-				return err
-			}
-			if _, ssaErr := s.sns.SetSubscriptionAttributes(&sns.SetSubscriptionAttributesInput{
-				SubscriptionArn: s.subscriptionArn,
-				AttributeName:   aws.String("FilterPolicy"),
-				AttributeValue:  newFilterPolicy,
-			}); ssaErr != nil {
-				return ssaErr
-			}
+			return nil
+		}
+
+		newFilterPolicy, err := encodeFilterPolicy(filter)
+		if err != nil {
+			return err
+		}
+		if _, ssaErr := s.sns.SetSubscriptionAttributes(&sns.SetSubscriptionAttributesInput{
+			SubscriptionArn: s.subscriptionArn,
+			AttributeName:   aws.String("FilterPolicy"),
+			AttributeValue:  newFilterPolicy,
+		}); ssaErr != nil {
+			return ssaErr
 		}
 	}
 

--- a/aws/subscriber.go
+++ b/aws/subscriber.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"time"
 
@@ -142,19 +143,46 @@ func (s *awsSubscriber) ensureSubscription(topic, subscriptionID string) error {
 }
 
 func (s *awsSubscriber) ensureFilterPolicy(filter map[string]string) error {
-	newFilterPolicy, err := encodeFilterPolicy(filter)
+	attrs, err := s.sns.GetSubscriptionAttributes(&sns.GetSubscriptionAttributesInput{SubscriptionArn: s.subscriptionArn})
 	if err != nil {
 		return err
 	}
-	if newFilterPolicy != nil {
-		_, ssaErr := s.sns.SetSubscriptionAttributes(&sns.SetSubscriptionAttributesInput{
-			SubscriptionArn: s.subscriptionArn,
-			AttributeName:   aws.String("FilterPolicy"),
-			AttributeValue:  newFilterPolicy,
-		})
-
-		return ssaErr
+	currentFilterPolicy, err := decodeFilterPolicy(attrs.Attributes["FilterPolicy"])
+	if err != nil || !reflect.DeepEqual(currentFilterPolicy, filter) {
+		/*
+		   If the new filter is empty, we need to delete the subscription and recreate it.
+		   This is needed because the AWS API won't allow you to set an empty FilterPolicy
+		*/
+		if len(filter) == 0 {
+			if _, err := s.sns.Unsubscribe(&sns.UnsubscribeInput{
+				SubscriptionArn: s.subscriptionArn,
+			}); err != nil {
+				return err
+			}
+			resp, err := s.sns.Subscribe(&sns.SubscribeInput{
+				Protocol: aws.String("sqs"),
+				TopicArn: s.topicArn,
+				Endpoint: s.queueArn,
+			})
+			if err != nil {
+				return err
+			}
+			s.subscriptionArn = resp.SubscriptionArn
+		} else {
+			newFilterPolicy, err := encodeFilterPolicy(filter)
+			if err != nil {
+				return err
+			}
+			if _, ssaErr := s.sns.SetSubscriptionAttributes(&sns.SetSubscriptionAttributesInput{
+				SubscriptionArn: s.subscriptionArn,
+				AttributeName:   aws.String("FilterPolicy"),
+				AttributeValue:  newFilterPolicy,
+			}); ssaErr != nil {
+				return ssaErr
+			}
+		}
 	}
+
 	return nil
 }
 

--- a/aws/subscriber_test.go
+++ b/aws/subscriber_test.go
@@ -21,7 +21,7 @@ func TestStart(t *testing.T) {
 
 	sqsMock := mockSQS{
 		stubbedReceiveMessageMessages: []*sqs.Message{
-			mustWrapIntoSQSMessage(expectedMessage, aws.String(expectedHandle), expectedMetadata),
+			mustWrapIntoSQSMessage(t, expectedMessage, aws.String(expectedHandle), expectedMetadata),
 			&sqs.Message{Body: aws.String("some mangled message")},
 		},
 	}
@@ -125,7 +125,7 @@ func TestStart_FilterPolicyError_ClosesMessageChannel(t *testing.T) {
 func TestEnsureFilterPolicy_NewFilterMatches_NoModificationDone(t *testing.T) {
 	filterPolicy := map[string]string{"foo": "bar"}
 	snsMock := &mockSNS{
-		stubbedGetSubscriptionAttributesOutput: &sns.GetSubscriptionAttributesOutput{Attributes: map[string]*string{"FilterPolicy": mustEncodeFilterPolicy(filterPolicy)}},
+		stubbedGetSubscriptionAttributesOutput: &sns.GetSubscriptionAttributesOutput{Attributes: map[string]*string{"FilterPolicy": mustEncodeFilterPolicy(t, filterPolicy)}},
 	}
 	subscriber := awsSubscriber{
 		sns: snsMock,
@@ -145,7 +145,7 @@ func TestEnsureFilterPolicy_ClearingFilter_ResubscribesToPolicy(t *testing.T) {
 	snsMock := &mockSNS{
 		stubbedGetSubscriptionAttributesOutput: &sns.GetSubscriptionAttributesOutput{
 			Attributes: map[string]*string{
-				"FilterPolicy": mustEncodeFilterPolicy(map[string]string{"foo": "bar"}),
+				"FilterPolicy": mustEncodeFilterPolicy(t, map[string]string{"foo": "bar"}),
 			},
 		},
 		stubbedSubscribeOutput: &sns.SubscribeOutput{SubscriptionArn: aws.String("NewSubscriptionArn")},
@@ -172,7 +172,7 @@ func TestEnsureFilterPolicy_DifferentPolicy_SetsSubscriptionAttributes(t *testin
 	snsMock := mockSNS{
 		stubbedGetSubscriptionAttributesOutput: &sns.GetSubscriptionAttributesOutput{
 			Attributes: map[string]*string{
-				"FilterPolicy": mustEncodeFilterPolicy(map[string]string{"foo": "bar"}),
+				"FilterPolicy": mustEncodeFilterPolicy(t, map[string]string{"foo": "bar"}),
 			},
 		},
 	}

--- a/aws/subscriber_test.go
+++ b/aws/subscriber_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
@@ -89,9 +90,9 @@ func TestStart(t *testing.T) {
 	}
 }
 
-// Verify that the channel is closed immediately if there are errors trying to
+// verify that the channel is closed immediately if there are errors trying to
 // set a filter policy
-func TestStart_EnsureFilter(t *testing.T) {
+func TestStart_FilterPolicyError_ClosesMessageChannel(t *testing.T) {
 	snsMock := mockSNS{}
 
 	s, serr := newSubscriber(&snsMock, &mockSQS{}, "topic", "subscriptionID")
@@ -117,5 +118,70 @@ func TestStart_EnsureFilter(t *testing.T) {
 				t.Errorf("expected msgChannel to be closed, but was open")
 			}
 		}
+	}
+}
+
+// verify that no calls to update the subscription happens if the passed-in filter matches the existing filter
+func TestEnsureFilterPolicy_NewFilterMatches_NoModificationDone(t *testing.T) {
+	filterPolicy := map[string]string{"foo": "bar"}
+	snsMock := &mockSNS{
+		stubbedGetSubscriptionAttributesOutput: &sns.GetSubscriptionAttributesOutput{Attributes: map[string]*string{"FilterPolicy": mustEncodeFilterPolicy(filterPolicy)}},
+	}
+	subscriber := awsSubscriber{
+		sns: snsMock,
+	}
+	subscriber.ensureFilterPolicy(filterPolicy)
+	if snsMock.spiedSubscribeInput != nil {
+		t.Error("sns.Subscribe was called, but shouldn't have been")
+	}
+	if snsMock.spiedSetSubscriptionAttributesInput != nil {
+		t.Error("sns.SetSubscriptionAttributes was called, but shouldn't have been")
+	}
+}
+
+// verify that if you're trying to clear a filter policy, it unsubscribes then
+// resubscribes
+func TestEnsureFilterPolicy_ClearingFilter_ResubscribesToPolicy(t *testing.T) {
+	snsMock := &mockSNS{
+		stubbedGetSubscriptionAttributesOutput: &sns.GetSubscriptionAttributesOutput{
+			Attributes: map[string]*string{
+				"FilterPolicy": mustEncodeFilterPolicy(map[string]string{"foo": "bar"}),
+			},
+		},
+		stubbedSubscribeOutput: &sns.SubscribeOutput{SubscriptionArn: aws.String("NewSubscriptionArn")},
+	}
+	subscriber := awsSubscriber{
+		sns:             snsMock,
+		subscriptionArn: aws.String("testSubscriptionArn"),
+	}
+	subscriber.ensureFilterPolicy(nil)
+	if snsMock.spiedUnsubscribeInput == nil {
+		t.Error("expected Unsubsribe to be called, but wasn't")
+	}
+	if snsMock.spiedSubscribeInput == nil {
+		t.Error("expected Subscribe to be called, but wasn't")
+	}
+	if snsMock.spiedSetSubscriptionAttributesInput != nil {
+		t.Error("SetSubscriptionAttributesInput was called, but shouldn't have been")
+	}
+}
+
+// verify that if you pass in a different filter than what was there, it'll update
+// the filter policy in SNS
+func TestEnsureFilterPolicy_DifferentPolicy_SetsSubscriptionAttributes(t *testing.T) {
+	snsMock := mockSNS{
+		stubbedGetSubscriptionAttributesOutput: &sns.GetSubscriptionAttributesOutput{
+			Attributes: map[string]*string{
+				"FilterPolicy": mustEncodeFilterPolicy(map[string]string{"foo": "bar"}),
+			},
+		},
+	}
+	subscriber := awsSubscriber{sns: &snsMock}
+	subscriber.ensureFilterPolicy(map[string]string{"baz": "qux"})
+	if snsMock.spiedSubscribeInput != nil {
+		t.Error("sns.Subscribe was called, but shouldn't have been")
+	}
+	if snsMock.spiedSetSubscriptionAttributesInput == nil {
+		t.Error("expected SetSubscriptionAttributes to be called, but wasn't")
 	}
 }


### PR DESCRIPTION
bugfix for #12 

I couldn't just create a new subscription, because an SNS subscription is unique for a given topic and queue.

I still don't like the potential holes for data leaks that are provided with this, but it's an improvement over what's currently there.