### PR TITLE
reuse the AWS session object for the server implementation

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -35,15 +35,10 @@ const topicNameMaxLength = 40 - len(topicNamePrefix)
 
 // VerifyPermissions checks if the aws config exists and checks if it has permissions to
 // create sns topics, send messages, create SQS topics, delete topics, and delete sqs queues
-func VerifyPermissions() error {
+func VerifyPermissions(sess *session.Session) error {
 	// Check if environment contains aws config
 	topic := "verifyPermissions"
 	subscriptionID := uuid.New().String()
-
-	sess, err := ensureSession()
-	if err != nil {
-		return err
-	}
 
 	log.Println("verify permissions: creating subscriber")
 	subscriber, err := newSubscriber(sns.New(sess), sqs.New(sess), topic, subscriptionID)
@@ -99,12 +94,6 @@ func verifyPermissions(subscriber *awsSubscriber, publisher *publisher) error {
 }
 
 // Utility functions for performing AWS commands (create SNS topic, SQS queue, etc)
-
-// ensureSession will handle creating a session with the passed-in config or a
-// default config if nil was passed in
-func ensureSession() (*session.Session, error) {
-	return session.NewSession()
-}
 
 // buildAWSTopicName takes in a topic name and returns a formatted version fitting
 // this broker's naming convention. Errors will be returned if the topic name is

--- a/aws/publisher.go
+++ b/aws/publisher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	pubsub "github.com/infobloxopen/atlas-pubsub"
@@ -16,11 +17,7 @@ import (
 // Topic names must be made up of only uppercase and lowercase
 // ASCII letters, numbers, underscores, and hyphens, and must be between 1 and
 // 247 characters long.
-func NewPublisher(topic string) (pubsub.Publisher, error) {
-	sess, err := ensureSession()
-	if err != nil {
-		return nil, err
-	}
+func NewPublisher(sess *session.Session, topic string) (pubsub.Publisher, error) {
 	return newPublisher(sns.New(sess), topic)
 }
 

--- a/aws/subscriber.go
+++ b/aws/subscriber.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -18,12 +19,7 @@ import (
 // the given topic with at-least-once message delivery semantics for the given
 // subscriptionID
 // TODO: info on permissions needed within the config to make this work
-func NewSubscriber(topic, subscriptionID string) (pubsub.Subscriber, error) {
-	sess, err := ensureSession()
-	if err != nil {
-		return nil, err
-	}
-
+func NewSubscriber(sess *session.Session, topic, subscriptionID string) (pubsub.Subscriber, error) {
 	return newSubscriber(sns.New(sess), sqs.New(sess), topic, subscriptionID)
 }
 


### PR DESCRIPTION
Based on the [AWS documentation](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/), sessions should be cached when possible.