### PR TITLE
Putting Ack() outside of the go func

### DIFF
--- a/examples/hello/subscriber/main.go
+++ b/examples/hello/subscriber/main.go
@@ -45,11 +45,9 @@ func main() {
 			}
 			greeting := string(msg.Message())
 			log.Printf("received message: %q\t%v", greeting, msg.Metadata())
-			go func() {
-				if err := msg.Ack(); err != nil {
-					log.Fatalf("failed to ack messageID %q: %v", msg.MessageID(), err)
-				}
-			}()
+			if err := msg.Ack(); err != nil {
+				log.Fatalf("failed to ack messageID %q: %v", msg.MessageID(), err)
+			}
 		case err := <-e:
 			log.Printf("encountered error reading subscription: %v", err)
 		}


### PR DESCRIPTION
@razamiDev I don't have permission to request reviewers. Can you review this please? :) Thanks

=========

Correct me if I'm wrong, but don't we want to wait for the message to `Ack()`?
Bringing this up because of issues internal to Infoblox. We could discuss this on somewhere other than Github if you'd like more details.