### PR TITLE
fix memory leak

### DIFF
--- a/aws/subscriber.go
+++ b/aws/subscriber.go
@@ -58,7 +58,7 @@ func (s *awsSubscriber) Start(ctx context.Context, opts ...pubsub.Option) (<-cha
 		opt(subscriberOptions)
 	}
 	msgChannel := make(chan pubsub.Message)
-	errChannel := make(chan error)
+	errChannel := make(chan error, 1)
 	go func() {
 		defer close(msgChannel)
 		defer close(errChannel)

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -80,6 +80,7 @@ func (w *grpcClientWrapper) Start(ctx context.Context, opts ...pubsub.Option) (<
 			select {
 			case <-w.cancel:
 				errC <- fmt.Errorf("PUBSUB client: stream closed for subscription %s, topic %s", w.subscriptionID, w.topic)
+				return
 			case <-stream.Context().Done():
 				errC <- fmt.Errorf("PUBSUB client: stream closed for subscription %s, topic %s", w.subscriptionID, w.topic)
 				return


### PR DESCRIPTION
* add mixed return on cancel channel in client wrapper
* refactor pull method to prevent fall trough into next loop  iteration after error happens
* fix partial lock which don't allow garbage collector to free memory 
