### PR TITLE
enable profiler for pubsub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,12 @@ COPY bin/pubsub /usr/local/bin/pubsub
 # Allows to verify certificates
 RUN apk update --no-cache && apk add --no-cache ca-certificates
 
-ENV AWS_REGION us-east-1 
+ENV AWS_REGION us-east-1
 
 # gRPC port
 EXPOSE 80
+
+# Profiler port
+EXPOSE 9999
 
 ENTRYPOINT ["/usr/local/bin/pubsub"]

--- a/examples/server/config.go
+++ b/examples/server/config.go
@@ -9,6 +9,11 @@ const (
 	defaultServerAddress = "0.0.0.0"
 	defaultServerPort    = "5555"
 
+	//Profiler
+	defaultProfilerEnabled = false
+	defaultProfilerAddress = "0.0.0.0"
+	defaultProfilerPort    = "9999"
+
 	// Health
 	defaultInternalEnable    = true
 	defaultInternalAddress   = "0.0.0.0"
@@ -24,6 +29,10 @@ var (
 	// define flag overrides
 	flagServerAddress = pflag.String("server.address", defaultServerAddress, "adress of gRPC server")
 	flagServerPort    = pflag.String("server.port", defaultServerPort, "port of gRPC server")
+
+	flagProfilerEnabled = pflag.Bool("profiler.enable", defaultProfilerEnabled, "enable profiler by default false")
+	flagProfilerAddress = pflag.String("profiler.address", defaultProfilerAddress, "address of profiler server")
+	flagProfilerPort    = pflag.String("profiler.port", defaultProfilerPort, "port of profiler server")
 
 	flagInternalEnable    = pflag.Bool("internal.enable", defaultInternalEnable, "enable internal http server")
 	flagInternalAddress   = pflag.String("internal.address", defaultInternalAddress, "address of internal http server")


### PR DESCRIPTION
We should discuss adding possibility to enable profiler by environment variable

* Add program arguments to enable profiler, set address and port
* set default configuration for envs
* import net/http/pprof to add profiling
* expose profiler API on default multiplexer