### PR TITLE
Add blank map to prevent helm coalesce error when it's overridden

### DIFF
--- a/deploy/pubsub/values.yaml
+++ b/deploy/pubsub/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 rbac:
   enabled: false
-  details:
+  details: {}
 
 imagePullSecretsName:
 


### PR DESCRIPTION
Overriding the rbac details currently yields the following error. Adding an empty map fixes the warning
```
coalesce.go:199: warning: destination for details is a table. Ignoring non-table value <nil>
```