### PR TITLE
examples: ack in a go routine

### DIFF
--- a/examples/hello/subscriber/main.go
+++ b/examples/hello/subscriber/main.go
@@ -45,11 +45,11 @@ func main() {
 			}
 			greeting := string(msg.Message())
 			log.Printf("received message: %q\t%v", greeting, msg.Metadata())
-			go func() {
+			go func(msg pubsub.Message) {
 				if err := msg.Ack(); err != nil {
-					log.Fatalf("failed to ack messageID %q: %v", msg.MessageID(), err)
+					log.Printf("failed to ack messageID %q: %v", msg.MessageID(), err)
 				}
-			}()
+			}(msg)
 		case err := <-e:
 			log.Printf("encountered error reading subscription: %v", err)
 		}

--- a/examples/protobuf/subscriber/main.go
+++ b/examples/protobuf/subscriber/main.go
@@ -6,12 +6,12 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/golang/protobuf/proto"
-	"github.com/infobloxopen/atlas-pubsub/examples/protobuf"
 	"log"
 	"strconv"
 
+	"github.com/golang/protobuf/proto"
 	pubsub "github.com/infobloxopen/atlas-pubsub"
+	"github.com/infobloxopen/atlas-pubsub/examples/protobuf"
 	pubsubgrpc "github.com/infobloxopen/atlas-pubsub/grpc"
 	"google.golang.org/grpc"
 )
@@ -46,11 +46,11 @@ func main() {
 
 			log.Printf("                   (Marshalled): %q", msg.Message())
 			log.Printf("Received message (Unmarshalled): %q %q %q %q", receivedPerson.GetName(), strconv.Itoa(int(receivedPerson.GetAge())), receivedPerson.EmployeeInfo.GetLocation(), receivedPerson.EmployeeInfo.GetTitle())
-			go func() {
+			go func(msg pubsub.Message) {
 				if err := msg.Ack(); err != nil {
-					log.Fatalf("failed to ack messageID %q: %v", msg.MessageID(), err)
+					log.Printf("failed to ack messageID %q: %v", msg.MessageID(), err)
 				}
-			}()
+			}(msg)
 		case err := <-e:
 			log.Printf("encountered error reading subscription: %v", err)
 		}


### PR DESCRIPTION
`Ack()` can be slow (#34), so it's advantageous to put it in a go routine. A previous version of the examples had this, but was buggy because it fell for https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables, and that's likely why it was removed in #42. By properly passing the value into the closure, it is safe to `Ack()` in a go routine.

cc @wsp93 