### PR TITLE
Allow specifying annotations to serviceaccount in chart

### DIFF
--- a/deploy/pubsub/templates/deployment.yaml
+++ b/deploy/pubsub/templates/deployment.yaml
@@ -6,6 +6,10 @@ apiVersion: v1
 metadata:
   name: pubsub
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 imagePullSecrets:
 - name: {{ tpl .Values.imagePullSecretsName . }}
 {{ end }}

--- a/deploy/pubsub/values.yaml
+++ b/deploy/pubsub/values.yaml
@@ -43,3 +43,7 @@ resources:
   requests:
     cpu: 200m
     memory: 400Mi
+
+serviceAccount:
+  # Annotations to add to the service account
+  annotations: {}


### PR DESCRIPTION
This PR allows to set annotations to the serviceaccount dynamically.