### PR TITLE
CVEs: Upgrade base packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,8 @@ COPY bin/pubsub /usr/local/bin/pubsub
 # Allows to verify certificates
 RUN apk update --no-cache && apk add --no-cache ca-certificates
 
+RUN apk upgrade
+
 ENV AWS_REGION us-east-1
 
 # gRPC port

--- a/docker/Dockerfile.publisher
+++ b/docker/Dockerfile.publisher
@@ -5,4 +5,6 @@ COPY bin/pubsub-pub /usr/local/bin/pubsub-pub
 # Allows to verify certificates
 RUN apk update --no-cache && apk add --no-cache ca-certificates
 
+RUN apk upgrade
+
 ENTRYPOINT ["/usr/local/bin/pubsub-pub"]

--- a/docker/Dockerfile.subscriber
+++ b/docker/Dockerfile.subscriber
@@ -5,4 +5,6 @@ COPY bin/pubsub-sub /usr/local/bin/pubsub-sub
 # Allows to verify certificates
 RUN apk update --no-cache && apk add --no-cache ca-certificates
 
+RUN apk upgrade
+
 ENTRYPOINT ["/usr/local/bin/pubsub-sub"]


### PR DESCRIPTION
Before:
NAME        INSTALLED  FIXED-IN  TYPE  VULNERABILITY  SEVERITY 
libcrypto3  3.1.3-r0   3.1.4-r1  apk   CVE-2023-5678  High      
libcrypto3  3.1.3-r0   3.1.4-r0  apk   CVE-2023-5363  High      
libssl3     3.1.3-r0   3.1.4-r1  apk   CVE-2023-5678  High      
libssl3     3.1.3-r0   3.1.4-r0  apk   CVE-2023-5363  High

After:
No CVEs
