### PR TITLE
Preserve workflow-injected IRSA role-arn annotation on pubsub ServiceAccount

### DIFF
--- a/deploy/pubsub/templates/deployment.yaml
+++ b/deploy/pubsub/templates/deployment.yaml
@@ -5,9 +5,12 @@ metadata:
   name: pubsub
   namespace: {{ .Release.Namespace }}
   {{- $saAnnotations := deepCopy (.Values.serviceAccount.annotations | default dict) }}
-  {{- $_ := set $saAnnotations "eks.amazonaws.com/role-arn" (tpl (.Values.serviceAccount.roleArn | default "") $) }}
+  {{- $roleArn := tpl (.Values.serviceAccount.roleArn | default "") $ }}
+  {{- if $roleArn }}
+  {{- $_ := set $saAnnotations "eks.amazonaws.com/role-arn" $roleArn }}
+  {{- end }}
   annotations:
-    {{- toYaml $saAnnotations | nindent 4 }}
+  {{- toYaml $saAnnotations | nindent 4 }}
   {{- with (tpl (.Values.imagePullSecretsName | default "") $) }}
 imagePullSecrets:
 - name: {{ . }}


### PR DESCRIPTION
## Problem
The `pubsub` ServiceAccount's `eks.amazonaws.com/role-arn` annotation can be silently blanked by the chart. Where that annotation is populated *outside* the chart (e.g. by a deploy-time process or an admission webhook), the workload ends up with no IRSA role, falls back to the node IAM role, fails its startup AWS permission check (`sqs:CreateQueue` AccessDenied), and crash-loops.

## Root cause
The ServiceAccount template copies `serviceAccount.annotations` but then **unconditionally** sets `eks.amazonaws.com/role-arn` from `serviceAccount.roleArn` (which defaults to `""`), overwriting any externally-provided value with an empty string:

```gotemplate
{{- $_ := set $saAnnotations "eks.amazonaws.com/role-arn" (tpl (.Values.serviceAccount.roleArn | default "") $) }}
```

Environments that re-set the annotation after render masked it; where nothing does, the empty value stuck. Introduced in #94.

## Fix
Set the annotation only when `serviceAccount.roleArn` is non-empty, so an externally-injected value is preserved while standalone installs can still set it.

## Validation (`helm template`)
- annotation supplied via `serviceAccount.annotations`, `roleArn` unset → preserved
- `roleArn` set explicitly → applied
- neither set → role-arn key omitted (no present-but-empty annotation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
